### PR TITLE
Support arrays input for OpenAI embeddings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
-- Update OpenAI Embeddings model to support string array input
+- Update OpenAI Embeddings model to support all allowed types of input
 
 ## 2024-06-28 - Version 0.1.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,16 @@
 
 ## UNRELEASED
 
+- Update OpenAI Embeddings model to support string array input
+
+## 2024-06-28 - Version 0.1.6
+
+- Interface changes and fixes
+
+## 2024-06-28 - Version 0.1.5
+
+- Interface changes and fixes
+
+## 2024-06-27 - Version 0.1.2
+
 - Initial Release

--- a/src/models/openai/embeddings.ts
+++ b/src/models/openai/embeddings.ts
@@ -6,17 +6,29 @@ export class EmbeddingsModel extends Model<EmbeddingsInput, EmbeddingsOutput> {
   createInput<T>(content: T): EmbeddingsInput {
     const model = this.info.fullName;
 
-    if (isString(content)) {
-      const input = content as string;
-      return <EmbeddingsStringInput>{ model, input };
+    switch (idof<T>()) {
+      case idof<string>():
+      case idof<string[]>():
+      case idof<i64[]>():
+      case idof<i32[]>():
+      case idof<i16[]>():
+      case idof<i8[]>():
+      case idof<u64[]>():
+      case idof<u32[]>():
+      case idof<u16[]>():
+      case idof<u8[]>():
+      case idof<i64[][]>():
+      case idof<i32[][]>():
+      case idof<i16[][]>():
+      case idof<i8[][]>():
+      case idof<u64[][]>():
+      case idof<u32[][]>():
+      case idof<u16[][]>():
+      case idof<u8[][]>():
+        return <TypedEmbeddingsInput<T>>{ model, input: content };
     }
 
-    if (idof<T>() == idof<string[]>()) {
-      const input = content as string[];
-      return <EmbeddingsStringArrayInput>{ model, input };
-    }
-
-    throw new Error("Content must be a string or an array of strings.");
+    throw new Error("Unsupported input content type.");
   }
 }
 
@@ -40,14 +52,8 @@ class EmbeddingsInput {
 
 
 @json
-class EmbeddingsStringInput extends EmbeddingsInput {
-  input!: string;
-}
-
-
-@json
-class EmbeddingsStringArrayInput extends EmbeddingsInput {
-  input!: string[];
+class TypedEmbeddingsInput<T> extends EmbeddingsInput {
+  input!: T;
 }
 
 

--- a/src/models/openai/embeddings.ts
+++ b/src/models/openai/embeddings.ts
@@ -3,16 +3,26 @@ import { Model } from "../..";
 // Reference: https://platform.openai.com/docs/api-reference/embeddings
 
 export class EmbeddingsModel extends Model<EmbeddingsInput, EmbeddingsOutput> {
-  createInput(text: string): EmbeddingsInput {
+  createInput<T>(content: T): EmbeddingsInput {
     const model = this.info.fullName;
-    return <EmbeddingsInput>{ model, input: text };
+
+    if (isString(content)) {
+      const input = content as string;
+      return <EmbeddingsStringInput>{ model, input };
+    }
+
+    if (idof<T>() == idof<string[]>()) {
+      const input = content as string[];
+      return <EmbeddingsStringArrayInput>{ model, input };
+    }
+
+    throw new Error("Content must be a string or an array of strings.");
   }
 }
 
 
 @json
 class EmbeddingsInput {
-  input!: string; // todo: support other types of input (arrays, etc.)
   model!: string;
 
 
@@ -26,6 +36,18 @@ class EmbeddingsInput {
 
   @omitnull()
   user: string | null = null;
+}
+
+
+@json
+class EmbeddingsStringInput extends EmbeddingsInput {
+  input!: string;
+}
+
+
+@json
+class EmbeddingsStringArrayInput extends EmbeddingsInput {
+  input!: string[];
 }
 
 


### PR DESCRIPTION
Input type can be any of:

- string
- array of strings
- array of integers
- array of array of integers

(Arrays of integers are for pre-tokenized input.)

See https://platform.openai.com/docs/api-reference/embeddings/create#embeddings-create-input

Completes HYP-1519